### PR TITLE
fix: make the GitHub icon bigger

### DIFF
--- a/src/components/header.module.scss
+++ b/src/components/header.module.scss
@@ -7,7 +7,8 @@
   max-width: 100%;
   margin-bottom: 2rem;
 
-  .icon_header {
-    padding-right: 0 !important;
+  .icon {
+    width: 1.2rem;
+    height: 1.2rem;
   }
 }

--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -15,10 +15,7 @@ export default function Header() {
         target={"_blank"}
         rel={"noopener noreferrer"}
       >
-        <BsGithub
-          className={`${styles.icon} ${styles.icon_header}`}
-          aria-label="github"
-        />
+        <BsGithub className={`${styles.icon}`} aria-label="github" />
       </Link>
     </header>
   );


### PR DESCRIPTION
🐙 