### PR TITLE
fix: move more on GitHub link upper

### DIFF
--- a/src/components/repos.module.scss
+++ b/src/components/repos.module.scss
@@ -16,7 +16,7 @@
   }
 
   .more {
-    margin-top: 1.2rem;
+    margin-top: 0.6rem;
     opacity: 0.9;
   }
 }


### PR DESCRIPTION
`margin-top: 1.2rem -> 0.6rem`