### PR TITLE
fix: font size is inconsistent between commit message and repo name

### DIFF
--- a/src/components/organisms/commits.module.scss
+++ b/src/components/organisms/commits.module.scss
@@ -19,7 +19,6 @@
 
     .message {
       margin-top: 0.4rem;
-      font-size: 0.8rem;
       opacity: 0.8;
     }
 


### PR DESCRIPTION
Easy mistake 😅 