### PR TITLE
Refactoring: dedupe formatters, easing, revalidate, and card grid

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ repositories, and the latest [Zenn](https://zenn.dev/yhakamay) articles.
 
 ## Stack
 
-- **[Next.js 15](https://nextjs.org/)** (App Router, RSC, Turbopack)
+- **[Next.js 16](https://nextjs.org/)** (App Router, RSC, Turbopack)
 - **[React 19](https://react.dev/)**
 - **[Tailwind CSS v4](https://tailwindcss.com/)** — CSS-first config, no `tailwind.config.js`
 - **[Motion](https://motion.dev/)** for scroll & entrance animations

--- a/src/components/card-grid.tsx
+++ b/src/components/card-grid.tsx
@@ -1,0 +1,25 @@
+import type { ReactNode } from "react";
+
+type CardGridProps<T> = {
+  items: T[];
+  /** Message shown when there are no items. */
+  empty: string;
+  children: (item: T, index: number) => ReactNode;
+};
+
+/**
+ * Responsive card grid shared by the Work and Writing sections. Renders
+ * the empty-state message when there's nothing to show, otherwise lays
+ * the items out via the render-prop child.
+ */
+export function CardGrid<T>({ items, empty, children }: CardGridProps<T>) {
+  if (items.length === 0) {
+    return <p className="text-sm text-(--muted)">{empty}</p>;
+  }
+
+  return (
+    <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+      {items.map(children)}
+    </div>
+  );
+}

--- a/src/components/command-palette.tsx
+++ b/src/components/command-palette.tsx
@@ -3,6 +3,7 @@
 import { AnimatePresence, motion } from "motion/react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
+import { EASE_OUT_SOFT } from "@/lib/motion";
 import { site } from "@/lib/site";
 
 /* ------------------------------------------------------------------ *
@@ -186,7 +187,7 @@ export function CommandPalette() {
           initial={{ opacity: 0, y: -12, scale: 0.98 }}
           animate={{ opacity: 1, y: 0, scale: 1 }}
           exit={{ opacity: 0, y: -8, scale: 0.98 }}
-          transition={{ duration: 0.22, ease: [0.22, 1, 0.36, 1] }}
+          transition={{ duration: 0.22, ease: EASE_OUT_SOFT }}
           // `position` + `top` are set inline: the `.glass` utility sets
           // `position: relative`, which would otherwise override Tailwind's
           // `fixed` and drop the panel to its static position.

--- a/src/components/hero.tsx
+++ b/src/components/hero.tsx
@@ -4,6 +4,7 @@ import Image from "next/image";
 import Link from "next/link";
 import { motion } from "motion/react";
 
+import { EASE_OUT_SOFT } from "@/lib/motion";
 import { site } from "@/lib/site";
 
 const container = {
@@ -18,7 +19,7 @@ const item = {
   show: {
     opacity: 1,
     y: 0,
-    transition: { duration: 0.7, ease: [0.22, 1, 0.36, 1] as const },
+    transition: { duration: 0.7, ease: EASE_OUT_SOFT },
   },
 };
 

--- a/src/components/journey.tsx
+++ b/src/components/journey.tsx
@@ -3,6 +3,7 @@
 import { AnimatePresence, motion } from "motion/react";
 import { useEffect, useState } from "react";
 
+import { EASE_OUT_SOFT } from "@/lib/motion";
 import { site } from "@/lib/site";
 
 /* ------------------------------------------------------------------ *
@@ -220,7 +221,7 @@ export function Journey() {
             initial={{ opacity: 0, y: 8 }}
             animate={{ opacity: 1, y: 0 }}
             exit={{ opacity: 0, y: -8 }}
-            transition={{ duration: 0.35, ease: [0.22, 1, 0.36, 1] }}
+            transition={{ duration: 0.35, ease: EASE_OUT_SOFT }}
             className="text-balance text-sm leading-relaxed text-(--muted)"
           >
             {current.note}

--- a/src/components/nav.tsx
+++ b/src/components/nav.tsx
@@ -4,6 +4,7 @@ import Link from "next/link";
 import { motion, useScroll, useMotionValueEvent } from "motion/react";
 import { useState } from "react";
 
+import { EASE_OUT_SOFT } from "@/lib/motion";
 import { site } from "@/lib/site";
 
 const links = [
@@ -24,7 +25,7 @@ export function Nav() {
     <motion.header
       initial={{ y: -80, opacity: 0 }}
       animate={{ y: 0, opacity: 1 }}
-      transition={{ duration: 0.6, ease: [0.22, 1, 0.36, 1] }}
+      transition={{ duration: 0.6, ease: EASE_OUT_SOFT }}
       className="fixed inset-x-0 top-0 z-50 flex justify-center px-4 pt-4"
     >
       <nav

--- a/src/components/projects.tsx
+++ b/src/components/projects.tsx
@@ -1,12 +1,6 @@
 import { SpotlightCard } from "@/components/spotlight-card";
+import { formatDate } from "@/lib/format";
 import { Repo } from "@/types/repo";
-
-function formatDate(iso: string) {
-  return new Date(iso).toLocaleDateString("en-US", {
-    year: "numeric",
-    month: "short",
-  });
-}
 
 export function Projects({ repos }: { repos: Repo[] }) {
   if (repos.length === 0) {

--- a/src/components/projects.tsx
+++ b/src/components/projects.tsx
@@ -1,52 +1,44 @@
+import { CardGrid } from "@/components/card-grid";
 import { SpotlightCard } from "@/components/spotlight-card";
 import { formatDate } from "@/lib/format";
 import { Repo } from "@/types/repo";
 
 export function Projects({ repos }: { repos: Repo[] }) {
-  if (repos.length === 0) {
-    return (
-      <p className="text-sm text-(--muted)">
-        Repositories are taking a break — check back soon.
-      </p>
-    );
-  }
-
   return (
-    <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-      {repos.map((repo, i) => {
-        return (
-          <SpotlightCard key={repo.id} href={repo.html_url} index={i}>
-            <div className="mb-3 flex items-center justify-between">
-              <span className="font-mono text-xs text-(--muted)">
-                {formatDate(repo.updated_at)}
+    <CardGrid
+      items={repos}
+      empty="Repositories are taking a break — check back soon."
+    >
+      {(repo, i) => (
+        <SpotlightCard key={repo.id} href={repo.html_url} index={i}>
+          <div className="mb-3 flex items-center justify-between">
+            <span className="font-mono text-xs text-(--muted)">
+              {formatDate(repo.updated_at)}
+            </span>
+            {repo.recent && (
+              <span className="rounded-full bg-(--color-accent)/15 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-(--color-accent)">
+                Recent
               </span>
-              {repo.recent && (
-                <span className="rounded-full bg-(--color-accent)/15 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-(--color-accent)">
-                  Recent
-                </span>
-              )}
-            </div>
-            <h3 className="text-lg font-semibold tracking-tight transition-colors group-hover:text-(--color-accent)">
-              {repo.name}
-            </h3>
-            <p className="mt-2 line-clamp-3 flex-1 text-sm leading-relaxed text-(--muted)">
-              {repo.description ?? "No description provided."}
-            </p>
-            <div className="mt-4 flex items-center gap-4 text-xs text-(--muted)">
-              {repo.language && (
-                <span className="inline-flex items-center gap-1.5">
-                  <span className="h-2 w-2 rounded-full bg-(--color-accent-2)" />
-                  {repo.language}
-                </span>
-              )}
-              {repo.stargazers_count > 0 && (
-                <span>★ {repo.stargazers_count}</span>
-              )}
-              {repo.forks_count > 0 && <span>⑂ {repo.forks_count}</span>}
-            </div>
-          </SpotlightCard>
-        );
-      })}
-    </div>
+            )}
+          </div>
+          <h3 className="text-lg font-semibold tracking-tight transition-colors group-hover:text-(--color-accent)">
+            {repo.name}
+          </h3>
+          <p className="mt-2 line-clamp-3 flex-1 text-sm leading-relaxed text-(--muted)">
+            {repo.description ?? "No description provided."}
+          </p>
+          <div className="mt-4 flex items-center gap-4 text-xs text-(--muted)">
+            {repo.language && (
+              <span className="inline-flex items-center gap-1.5">
+                <span className="h-2 w-2 rounded-full bg-(--color-accent-2)" />
+                {repo.language}
+              </span>
+            )}
+            {repo.stargazers_count > 0 && <span>★ {repo.stargazers_count}</span>}
+            {repo.forks_count > 0 && <span>⑂ {repo.forks_count}</span>}
+          </div>
+        </SpotlightCard>
+      )}
+    </CardGrid>
   );
 }

--- a/src/components/reveal.tsx
+++ b/src/components/reveal.tsx
@@ -3,6 +3,8 @@
 import { motion } from "motion/react";
 import type { ReactNode } from "react";
 
+import { EASE_OUT_SOFT } from "@/lib/motion";
+
 type RevealProps = {
   children: ReactNode;
   delay?: number;
@@ -18,7 +20,7 @@ export function Reveal({ children, delay = 0, y = 24, className }: RevealProps) 
       initial={{ opacity: 0, y }}
       whileInView={{ opacity: 1, y: 0 }}
       viewport={{ once: true, margin: "-80px" }}
-      transition={{ duration: 0.7, delay, ease: [0.22, 1, 0.36, 1] }}
+      transition={{ duration: 0.7, delay, ease: EASE_OUT_SOFT }}
     >
       {children}
     </motion.div>

--- a/src/components/skills.tsx
+++ b/src/components/skills.tsx
@@ -2,6 +2,7 @@
 
 import { motion } from "motion/react";
 
+import { EASE_OUT_SOFT } from "@/lib/motion";
 import { site } from "@/lib/site";
 
 export function Skills() {
@@ -16,7 +17,7 @@ export function Skills() {
           transition={{
             duration: 0.4,
             delay: i * 0.05,
-            ease: [0.22, 1, 0.36, 1],
+            ease: EASE_OUT_SOFT,
           }}
           whileHover={{ y: -3 }}
           className="glass rounded-xl px-4 py-2.5 text-sm font-medium"

--- a/src/components/spotlight-card.tsx
+++ b/src/components/spotlight-card.tsx
@@ -4,6 +4,8 @@ import Link from "next/link";
 import { motion, useMotionTemplate, useMotionValue } from "motion/react";
 import type { MouseEvent, ReactNode } from "react";
 
+import { EASE_OUT_SOFT } from "@/lib/motion";
+
 type SpotlightCardProps = {
   href: string;
   index?: number;
@@ -28,7 +30,7 @@ export function SpotlightCard({ href, index = 0, children }: SpotlightCardProps)
       initial={{ opacity: 0, y: 24 }}
       whileInView={{ opacity: 1, y: 0 }}
       viewport={{ once: true, margin: "-60px" }}
-      transition={{ duration: 0.6, delay: index * 0.08, ease: [0.22, 1, 0.36, 1] }}
+      transition={{ duration: 0.6, delay: index * 0.08, ease: EASE_OUT_SOFT }}
     >
       <Link
         href={href}

--- a/src/components/writing.tsx
+++ b/src/components/writing.tsx
@@ -1,19 +1,12 @@
+import { CardGrid } from "@/components/card-grid";
 import { SpotlightCard } from "@/components/spotlight-card";
 import { formatDate } from "@/lib/format";
 import { Article } from "@/types/article";
 
 export function Writing({ articles }: { articles: Article[] }) {
-  if (articles.length === 0) {
-    return (
-      <p className="text-sm text-(--muted)">
-        No articles yet — words are brewing.
-      </p>
-    );
-  }
-
   return (
-    <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-      {articles.map((article, i) => (
+    <CardGrid items={articles} empty="No articles yet — words are brewing.">
+      {(article, i) => (
         <SpotlightCard key={article.guid} href={article.link} index={i}>
           <span className="font-mono text-xs text-(--muted)">
             {formatDate(article.pubDate, {
@@ -35,7 +28,7 @@ export function Writing({ articles }: { articles: Article[] }) {
             </span>
           </span>
         </SpotlightCard>
-      ))}
-    </div>
+      )}
+    </CardGrid>
   );
 }

--- a/src/components/writing.tsx
+++ b/src/components/writing.tsx
@@ -1,15 +1,6 @@
 import { SpotlightCard } from "@/components/spotlight-card";
+import { formatDate } from "@/lib/format";
 import { Article } from "@/types/article";
-
-function formatDate(value: string) {
-  const d = new Date(value);
-  if (Number.isNaN(d.getTime())) return "";
-  return d.toLocaleDateString("en-US", {
-    year: "numeric",
-    month: "short",
-    day: "numeric",
-  });
-}
 
 export function Writing({ articles }: { articles: Article[] }) {
   if (articles.length === 0) {
@@ -25,7 +16,11 @@ export function Writing({ articles }: { articles: Article[] }) {
       {articles.map((article, i) => (
         <SpotlightCard key={article.guid} href={article.link} index={i}>
           <span className="font-mono text-xs text-(--muted)">
-            {formatDate(article.pubDate)}
+            {formatDate(article.pubDate, {
+              year: "numeric",
+              month: "short",
+              day: "numeric",
+            })}
           </span>
           <h3 className="mt-3 line-clamp-2 text-lg font-semibold tracking-tight transition-colors group-hover:text-(--color-accent)">
             {article.title}

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -1,0 +1,5 @@
+/**
+ * Cache lifetime, in seconds, for upstream feeds (GitHub repos, Zenn
+ * articles) fetched at the data layer and revalidated by Next.js.
+ */
+export const REVALIDATE_SECONDS = 60 * 60 * 6; // 6h

--- a/src/lib/format.ts
+++ b/src/lib/format.ts
@@ -1,0 +1,12 @@
+/**
+ * Format an ISO date string for display. Returns an empty string for
+ * unparseable input so callers can render it without guarding themselves.
+ */
+export function formatDate(
+  value: string,
+  options: Intl.DateTimeFormatOptions = { year: "numeric", month: "short" }
+): string {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return "";
+  return date.toLocaleDateString("en-US", options);
+}

--- a/src/lib/github.ts
+++ b/src/lib/github.ts
@@ -1,7 +1,7 @@
+import { REVALIDATE_SECONDS } from "@/lib/constants";
 import { Repo } from "@/types/repo";
 
 const USERNAME = "yhakamay";
-const REVALIDATE = 60 * 60 * 6; // 6h
 const RECENT_MS = 14 * 24 * 60 * 60 * 1000; // 14 days
 
 /** Fetch the user's public repositories, sorted by most recently updated. */
@@ -16,7 +16,7 @@ export async function getRepos(limit = 6): Promise<Repo[]> {
   try {
     const res = await fetch(
       `https://api.github.com/users/${USERNAME}/repos?sort=updated&direction=desc&per_page=100`,
-      { headers, next: { revalidate: REVALIDATE } }
+      { headers, next: { revalidate: REVALIDATE_SECONDS } }
     );
 
     if (!res.ok) {

--- a/src/lib/motion.ts
+++ b/src/lib/motion.ts
@@ -1,0 +1,7 @@
+/**
+ * Shared "soft ease-out" curve used across entrance and scroll animations.
+ * Mirrors the `--ease-out-soft` CSS token in globals.css.
+ */
+export const EASE_OUT_SOFT: [number, number, number, number] = [
+  0.22, 1, 0.36, 1,
+];

--- a/src/lib/zenn.ts
+++ b/src/lib/zenn.ts
@@ -1,9 +1,9 @@
 import { XMLParser } from "fast-xml-parser";
 
+import { REVALIDATE_SECONDS } from "@/lib/constants";
 import { Article } from "@/types/article";
 
 const FEED_URL = "https://zenn.dev/yhakamay/feed";
-const REVALIDATE = 60 * 60 * 6; // 6h
 
 type RawItem = {
   title?: string;
@@ -18,7 +18,9 @@ const parser = new XMLParser({ ignoreAttributes: false });
 /** Fetch and parse the latest Zenn articles from the RSS feed. */
 export async function getArticles(limit = 6): Promise<Article[]> {
   try {
-    const res = await fetch(FEED_URL, { next: { revalidate: REVALIDATE } });
+    const res = await fetch(FEED_URL, {
+      next: { revalidate: REVALIDATE_SECONDS },
+    });
 
     if (!res.ok) {
       throw new Error(`Zenn feed: ${res.status} ${res.statusText}`);


### PR DESCRIPTION
A set of low-risk, behavior-preserving refactors from a broader codebase review. Each is its own commit. No visual or runtime behavior changes.

## Changes

### 1. Consolidate duplicated `formatDate`
`Projects` and `Writing` each defined their own date formatter:
- `projects.tsx` — `{ year, month }`, **no** guard against invalid dates
- `writing.tsx` — `{ year, month, day }`, NaN-safe

Now a single NaN-safe helper in `src/lib/format.ts` taking optional `Intl.DateTimeFormatOptions`. Both call sites keep their exact output; `Projects` gains the invalid-date guard it previously lacked.

### 2. Fix README stack version
README listed **Next.js 15** while `package.json` pins `next@^16.2.9` → updated to **16**.

### 3. Centralize the soft ease-out curve
`cubic-bezier [0.22, 1, 0.36, 1]` was hardcoded in seven motion components. Extracted to `EASE_OUT_SOFT` in `src/lib/motion.ts`, mirroring the existing `--ease-out-soft` CSS token.

### 4. Share the feed revalidate interval
The 6h revalidate value was duplicated in `github.ts` and `zenn.ts`. Moved to `REVALIDATE_SECONDS` in `src/lib/constants.ts`.

### 5. Extract a shared `CardGrid`
`Projects` and `Writing` duplicated the empty-state message + responsive grid wrapper. Introduced a generic `CardGrid` (`src/components/card-grid.tsx`) that owns both, with each section supplying its items, empty message, and a render-prop for the card body.

## Verification
- `npm run lint` ✅
- `npm run build` ✅

## Note
A further proposal — centralizing the section/nav metadata that's currently duplicated across `page.tsx`, `nav.tsx`, and `command-palette.tsx` — was deferred because it involves a behavior decision (the command palette currently omits "Journey"). Happy to follow up if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)