### PR TITLE
Experiment: liquid surfaces instead of liquid glass (CSS-only gel)

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -27,12 +27,18 @@
   --card: oklch(1 0 0 / 0.55);
   --border: oklch(0.5 0.02 280 / 0.16);
 
-  /* Liquid-glass layers (light) */
-  --glass-tint: oklch(1 0 0 / 0.2); /* frosted fill over the refraction */
-  --glass-shine-1: oklch(1 0 0 / 0.6); /* bright rim, top-left */
-  --glass-shine-2: oklch(1 0 0 / 0.5); /* softer rim, bottom-right */
-  --glass-shadow: oklch(0.2 0.03 280 / 0.18); /* soft float */
-  --glass-shadow-2: oklch(0.2 0.03 280 / 0.08);
+  /* Liquid (water / slime) layers — light.
+     The body is a saturated, tinted translucency; the surface is a wet
+     glint over a volumetric inner shadow. */
+  --liquid-edge: oklch(1 0 0 / 0.45); /* surface-tension rim */
+  --liquid-tint: color-mix(in oklch, var(--color-accent-2) 14%, oklch(1 0 0 / 0.34));
+  --liquid-tint-hi: color-mix(in oklch, var(--color-accent-2) 22%, oklch(1 0 0 / 0.2));
+  --liquid-glint: oklch(1 0 0 / 0.8); /* bright wet highlight blob */
+  --liquid-shine: oklch(1 0 0 / 0.9); /* specular rim, top-left */
+  --liquid-shine-soft: oklch(1 0 0 / 0.4);
+  --liquid-depth: color-mix(in oklch, var(--color-accent) 30%, oklch(0.2 0.03 280 / 0.35)); /* volume */
+  --liquid-shadow: oklch(0.2 0.03 280 / 0.2); /* soft float */
+  --liquid-shadow-2: oklch(0.2 0.03 280 / 0.1);
   color-scheme: light;
 }
 
@@ -44,12 +50,17 @@
     --card: oklch(0.99 0.01 280 / 0.05);
     --border: oklch(0.99 0.01 280 / 0.1);
 
-    /* Liquid-glass layers (dark) */
-    --glass-tint: oklch(1 0 0 / 0.06);
-    --glass-shine-1: oklch(1 0 0 / 0.22);
-    --glass-shine-2: oklch(1 0 0 / 0.14);
-    --glass-shadow: oklch(0 0 0 / 0.5);
-    --glass-shadow-2: oklch(0 0 0 / 0.28);
+    /* Liquid (water / slime) layers — dark. A deeper, more saturated
+       gel with quieter wet highlights. */
+    --liquid-edge: oklch(1 0 0 / 0.16);
+    --liquid-tint: color-mix(in oklch, var(--color-accent) 22%, oklch(0.2 0.04 285 / 0.4));
+    --liquid-tint-hi: color-mix(in oklch, var(--color-accent-2) 30%, oklch(0.3 0.06 280 / 0.25));
+    --liquid-glint: oklch(1 0 0 / 0.4);
+    --liquid-shine: oklch(1 0 0 / 0.45);
+    --liquid-shine-soft: oklch(1 0 0 / 0.14);
+    --liquid-depth: oklch(0 0 0 / 0.55);
+    --liquid-shadow: oklch(0 0 0 / 0.55);
+    --liquid-shadow-2: oklch(0 0 0 / 0.3);
     color-scheme: dark;
   }
 }
@@ -99,59 +110,94 @@ body {
   text-wrap: balance;
 }
 
-/* ---- Liquid glass --------------------------------------------------
- * iOS/macOS-style glass, built in layers so any element tagged `.glass`
- * picks it up without markup changes:
- *   ::before  refraction + tint — a blurred, displacement-warped sample
- *             of the backdrop (the #glass-distortion SVG filter bends it
- *             at the edges the way real glass does)
+/* ---- Liquid (water / slime) ---------------------------------------
+ * Surfaces tagged `.liquid` read as a soft, wet blob of gel rather than
+ * a pane of glass — built in layers so any element picks it up without
+ * markup changes:
+ *   ::before  the body of the liquid — a saturated, tinted translucency
+ *             warped by the #liquid-distortion SVG filter (animated
+ *             turbulence → the backdrop ripples through it like water)
+ *             and gently jiggling so the volume feels alive
  *   content   the element's own children
- *   ::after   specular shine — bright inner rim, strong top-left
- * The drop shadow lifts the panel off the page.
+ *   ::after   the wet surface — a bright specular glint top-left over a
+ *             rounded inner shadow that gives the blob real volume
+ * The drop shadow + soft inner highlight sell the weight of the fluid.
  * ------------------------------------------------------------------ */
-.glass {
+.liquid {
   position: relative;
   isolation: isolate;
   overflow: hidden;
-  border: 1px solid var(--border);
+  border: 1px solid var(--liquid-edge);
   box-shadow:
-    0 6px 16px -6px var(--glass-shadow),
-    0 2px 6px -2px var(--glass-shadow-2);
+    0 10px 30px -12px var(--liquid-shadow),
+    0 4px 10px -7px var(--liquid-shadow-2),
+    inset 0 1px 0 0 var(--liquid-shine-soft);
 }
 
-.glass::before {
+.liquid::before {
   content: "";
   position: absolute;
-  inset: 0;
+  inset: -2px; /* let the warped body bleed past the edge */
   z-index: -1;
   border-radius: inherit;
-  background: var(--glass-tint);
-  /* One backdrop pass; keep the blur light so the displacement warp
-     stays legible. The SVG filter does the refraction. */
-  backdrop-filter: blur(1px) saturate(160%);
-  -webkit-backdrop-filter: blur(1px) saturate(160%);
-  filter: url(#glass-distortion);
+  background:
+    radial-gradient(125% 100% at 30% 0%, var(--liquid-tint-hi), transparent 62%),
+    var(--liquid-tint);
+  /* Backdrop pass; the saturation boost makes the gel feel wet. The SVG
+     filter does the rippling water refraction. */
+  backdrop-filter: blur(2px) saturate(200%);
+  -webkit-backdrop-filter: blur(2px) saturate(200%);
+  filter: url(#liquid-distortion);
+  animation: liquid-jiggle 7s ease-in-out infinite;
 }
 
-.glass::after {
+.liquid::after {
   content: "";
   position: absolute;
   inset: 0;
   z-index: 1;
   border-radius: inherit;
   pointer-events: none;
+  background: radial-gradient(
+    42% 30% at 26% 16%,
+    var(--liquid-glint),
+    transparent 70%
+  );
   box-shadow:
-    inset 1.5px 1.5px 1px -1px var(--glass-shine-1),
-    inset -1px -1px 1px -0.5px var(--glass-shine-2),
-    inset 0 0 6px 0 var(--glass-shine-2);
+    inset 2px 3px 5px -3px var(--liquid-shine),
+    inset -2px -3px 8px -4px var(--liquid-depth),
+    inset 0 0 14px 0 var(--liquid-shine-soft);
+  mix-blend-mode: screen;
+}
+
+/* The body of the liquid slowly shifts inside the surface — content
+   stays put, only the gel jostles, the way a filled jelly would. */
+@keyframes liquid-jiggle {
+  0%,
+  100% {
+    transform: translate3d(0, 0, 0) scale(1.02, 1.02);
+  }
+  33% {
+    transform: translate3d(-1.5%, 1%, 0) scale(1.05, 1.04);
+  }
+  66% {
+    transform: translate3d(1.5%, -1%, 0) scale(1.04, 1.06);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .liquid::before {
+    animation: none;
+  }
 }
 
 /* Where backdrop-filter (or the SVG filter) is unavailable, the tint
-   still reads as a simple frosted panel. */
+   still reads as a simple translucent gel panel. */
 @supports not ((backdrop-filter: blur(1px)) or
   (-webkit-backdrop-filter: blur(1px))) {
-  .glass::before {
-    background: var(--card);
+  .liquid::before {
+    background: var(--liquid-tint);
+    filter: none;
   }
 }
 
@@ -167,7 +213,8 @@ body {
   color: transparent;
 }
 
-/* Animated aurora blobs */
+/* Animated aurora blobs — drifting while their outline morphs, so the
+   background reads as slow-moving pools of liquid. */
 @keyframes drift {
   0%,
   100% {
@@ -178,6 +225,19 @@ body {
   }
   66% {
     transform: translate3d(-7%, 5%, 0) scale(0.94);
+  }
+}
+
+@keyframes liquid-morph {
+  0%,
+  100% {
+    border-radius: 42% 58% 57% 43% / 45% 47% 53% 55%;
+  }
+  33% {
+    border-radius: 62% 38% 45% 55% / 55% 62% 38% 45%;
+  }
+  66% {
+    border-radius: 45% 55% 62% 38% / 38% 45% 55% 62%;
   }
 }
 
@@ -198,21 +258,25 @@ body {
   border-radius: 50%;
   filter: blur(80px);
   opacity: 0.5;
-  will-change: transform;
+  will-change: transform, border-radius;
 }
 
 .aurora::before {
   top: -15%;
   left: -10%;
   background: radial-gradient(circle, var(--color-accent), transparent 65%);
-  animation: drift 18s var(--ease-out-soft) infinite;
+  animation:
+    drift 18s var(--ease-out-soft) infinite,
+    liquid-morph 14s ease-in-out infinite;
 }
 
 .aurora::after {
   bottom: -20%;
   right: -10%;
   background: radial-gradient(circle, var(--color-accent-2), transparent 65%);
-  animation: drift 22s var(--ease-out-soft) infinite reverse;
+  animation:
+    drift 22s var(--ease-out-soft) infinite reverse,
+    liquid-morph 17s ease-in-out infinite reverse;
 }
 
 @media (prefers-color-scheme: dark) {

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -27,17 +27,17 @@
   --card: oklch(1 0 0 / 0.55);
   --border: oklch(0.5 0.02 280 / 0.16);
 
-  /* Liquid (water / slime) layers — light.
-     The body is a saturated, tinted translucency; the surface is a wet
-     glint over a volumetric inner shadow. */
-  --liquid-edge: oklch(1 0 0 / 0.45); /* surface-tension rim */
-  --liquid-tint: color-mix(in oklch, var(--color-accent-2) 14%, oklch(1 0 0 / 0.34));
-  --liquid-tint-hi: color-mix(in oklch, var(--color-accent-2) 22%, oklch(1 0 0 / 0.2));
-  --liquid-glint: oklch(1 0 0 / 0.8); /* bright wet highlight blob */
-  --liquid-shine: oklch(1 0 0 / 0.9); /* specular rim, top-left */
-  --liquid-shine-soft: oklch(1 0 0 / 0.4);
-  --liquid-depth: color-mix(in oklch, var(--color-accent) 30%, oklch(0.2 0.03 280 / 0.35)); /* volume */
-  --liquid-shadow: oklch(0.2 0.03 280 / 0.2); /* soft float */
+  /* Liquid (water / slime) layers — light. CSS-only gel: a translucent
+     tinted body the backdrop shows through, plus wet highlights and a
+     volumetric inner shadow. No backdrop-filter / SVG filter (keeps
+     scrolling smooth and stops the body bleeding past rounded corners). */
+  --liquid-fill: oklch(1 0 0 / 0.5); /* translucent gel body */
+  --liquid-tint: color-mix(in oklch, var(--color-accent-2) 18%, oklch(1 0 0 / 0.5));
+  --liquid-glint: oklch(1 0 0 / 0.95); /* bright specular point */
+  --liquid-sheen: oklch(1 0 0 / 0.85); /* travelling wet sheen */
+  --liquid-edge: oklch(1 0 0 / 0.55); /* surface-tension rim */
+  --liquid-depth: oklch(0.45 0.12 285 / 0.28); /* bottom volume */
+  --liquid-shadow: oklch(0.2 0.03 280 / 0.22); /* soft float */
   --liquid-shadow-2: oklch(0.2 0.03 280 / 0.1);
   color-scheme: light;
 }
@@ -52,13 +52,12 @@
 
     /* Liquid (water / slime) layers — dark. A deeper, more saturated
        gel with quieter wet highlights. */
-    --liquid-edge: oklch(1 0 0 / 0.16);
-    --liquid-tint: color-mix(in oklch, var(--color-accent) 22%, oklch(0.2 0.04 285 / 0.4));
-    --liquid-tint-hi: color-mix(in oklch, var(--color-accent-2) 30%, oklch(0.3 0.06 280 / 0.25));
-    --liquid-glint: oklch(1 0 0 / 0.4);
-    --liquid-shine: oklch(1 0 0 / 0.45);
-    --liquid-shine-soft: oklch(1 0 0 / 0.14);
-    --liquid-depth: oklch(0 0 0 / 0.55);
+    --liquid-fill: oklch(0.6 0.12 285 / 0.16);
+    --liquid-tint: color-mix(in oklch, var(--color-accent) 26%, oklch(0.3 0.05 285 / 0.2));
+    --liquid-glint: oklch(1 0 0 / 0.55);
+    --liquid-sheen: oklch(1 0 0 / 0.34);
+    --liquid-edge: oklch(1 0 0 / 0.18);
+    --liquid-depth: oklch(0 0 0 / 0.5);
     --liquid-shadow: oklch(0 0 0 / 0.55);
     --liquid-shadow-2: oklch(0 0 0 / 0.3);
     color-scheme: dark;
@@ -112,92 +111,70 @@ body {
 
 /* ---- Liquid (water / slime) ---------------------------------------
  * Surfaces tagged `.liquid` read as a soft, wet blob of gel rather than
- * a pane of glass — built in layers so any element picks it up without
- * markup changes:
- *   ::before  the body of the liquid — a saturated, tinted translucency
- *             warped by the #liquid-distortion SVG filter (animated
- *             turbulence → the backdrop ripples through it like water)
- *             and gently jiggling so the volume feels alive
- *   content   the element's own children
- *   ::after   the wet surface — a bright specular glint top-left over a
- *             rounded inner shadow that gives the blob real volume
- * The drop shadow + soft inner highlight sell the weight of the fluid.
+ * a pane of glass — and it's built entirely from cheap, GPU-friendly
+ * primitives (gradients + shadows + a transform-only sheen). No
+ * backdrop-filter and no SVG filter: those caused the body to bleed past
+ * rounded corners on iOS and made scrolling janky.
+ *   element    a translucent, tinted gel body (the backdrop shows
+ *              through) with a specular point baked in, a crisp wet rim
+ *              and a volumetric inner shadow for weight
+ *   ::before   a wet sheen of light that slowly slides across the
+ *              surface — animated with transform only, so it's composited
+ *              and never repaints on scroll
  * ------------------------------------------------------------------ */
 .liquid {
   position: relative;
   isolation: isolate;
   overflow: hidden;
   border: 1px solid var(--liquid-edge);
+  /* Translucent gel body — backdrop shows through tinted, no blur. */
+  background:
+    radial-gradient(34% 26% at 22% 14%, var(--liquid-glint), transparent 60%),
+    radial-gradient(140% 120% at 30% 0%, var(--liquid-tint), transparent 64%),
+    var(--liquid-fill);
   box-shadow:
-    0 10px 30px -12px var(--liquid-shadow),
-    0 4px 10px -7px var(--liquid-shadow-2),
-    inset 0 1px 0 0 var(--liquid-shine-soft);
+    0 12px 28px -16px var(--liquid-shadow),
+    0 3px 8px -5px var(--liquid-shadow-2),
+    inset 0 1px 1px 0 var(--liquid-sheen),
+    inset 0 -10px 16px -12px var(--liquid-depth);
 }
 
 .liquid::before {
   content: "";
   position: absolute;
-  inset: -2px; /* let the warped body bleed past the edge */
+  inset: -40% -12%;
   z-index: -1;
-  border-radius: inherit;
-  background:
-    radial-gradient(125% 100% at 30% 0%, var(--liquid-tint-hi), transparent 62%),
-    var(--liquid-tint);
-  /* Backdrop pass; the saturation boost makes the gel feel wet. The SVG
-     filter does the rippling water refraction. */
-  backdrop-filter: blur(2px) saturate(200%);
-  -webkit-backdrop-filter: blur(2px) saturate(200%);
-  filter: url(#liquid-distortion);
-  animation: liquid-jiggle 7s ease-in-out infinite;
-}
-
-.liquid::after {
-  content: "";
-  position: absolute;
-  inset: 0;
-  z-index: 1;
-  border-radius: inherit;
   pointer-events: none;
-  background: radial-gradient(
-    42% 30% at 26% 16%,
-    var(--liquid-glint),
-    transparent 70%
+  background: linear-gradient(
+    122deg,
+    transparent 40%,
+    var(--liquid-sheen) 49%,
+    transparent 58%
   );
-  box-shadow:
-    inset 2px 3px 5px -3px var(--liquid-shine),
-    inset -2px -3px 8px -4px var(--liquid-depth),
-    inset 0 0 14px 0 var(--liquid-shine-soft);
-  mix-blend-mode: screen;
+  opacity: 0.5;
+  transform: translate3d(-14%, 0, 0);
+  animation: liquid-sheen 9s var(--ease-out-soft) infinite;
+  will-change: transform;
 }
 
-/* The body of the liquid slowly shifts inside the surface — content
-   stays put, only the gel jostles, the way a filled jelly would. */
-@keyframes liquid-jiggle {
+.liquid:hover::before {
+  opacity: 0.85;
+}
+
+/* A band of light drifting side to side — transform only (composited). */
+@keyframes liquid-sheen {
   0%,
   100% {
-    transform: translate3d(0, 0, 0) scale(1.02, 1.02);
+    transform: translate3d(-14%, 0, 0);
   }
-  33% {
-    transform: translate3d(-1.5%, 1%, 0) scale(1.05, 1.04);
-  }
-  66% {
-    transform: translate3d(1.5%, -1%, 0) scale(1.04, 1.06);
+  50% {
+    transform: translate3d(14%, 0, 0);
   }
 }
 
 @media (prefers-reduced-motion: reduce) {
   .liquid::before {
     animation: none;
-  }
-}
-
-/* Where backdrop-filter (or the SVG filter) is unavailable, the tint
-   still reads as a simple translucent gel panel. */
-@supports not ((backdrop-filter: blur(1px)) or
-  (-webkit-backdrop-filter: blur(1px))) {
-  .liquid::before {
-    background: var(--liquid-tint);
-    filter: none;
   }
 }
 
@@ -213,8 +190,8 @@ body {
   color: transparent;
 }
 
-/* Animated aurora blobs — drifting while their outline morphs, so the
-   background reads as slow-moving pools of liquid. */
+/* Animated aurora blobs — drifting pools of colour behind the gel.
+   Transform-only so they stay composited and don't repaint on scroll. */
 @keyframes drift {
   0%,
   100% {
@@ -225,19 +202,6 @@ body {
   }
   66% {
     transform: translate3d(-7%, 5%, 0) scale(0.94);
-  }
-}
-
-@keyframes liquid-morph {
-  0%,
-  100% {
-    border-radius: 42% 58% 57% 43% / 45% 47% 53% 55%;
-  }
-  33% {
-    border-radius: 62% 38% 45% 55% / 55% 62% 38% 45%;
-  }
-  66% {
-    border-radius: 45% 55% 62% 38% / 38% 45% 55% 62%;
   }
 }
 
@@ -258,25 +222,21 @@ body {
   border-radius: 50%;
   filter: blur(80px);
   opacity: 0.5;
-  will-change: transform, border-radius;
+  will-change: transform;
 }
 
 .aurora::before {
   top: -15%;
   left: -10%;
   background: radial-gradient(circle, var(--color-accent), transparent 65%);
-  animation:
-    drift 18s var(--ease-out-soft) infinite,
-    liquid-morph 14s ease-in-out infinite;
+  animation: drift 18s var(--ease-out-soft) infinite;
 }
 
 .aurora::after {
   bottom: -20%;
   right: -10%;
   background: radial-gradient(circle, var(--color-accent-2), transparent 65%);
-  animation:
-    drift 22s var(--ease-out-soft) infinite reverse,
-    liquid-morph 17s ease-in-out infinite reverse;
+  animation: drift 22s var(--ease-out-soft) infinite reverse;
 }
 
 @media (prefers-color-scheme: dark) {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -62,50 +62,6 @@ export default function RootLayout({
         <div className="noise" aria-hidden />
         {children}
         <CommandPalette />
-        {/* Refraction filter for .liquid surfaces — ripples the backdrop
-            like water. The turbulence drifts over time so the gel looks
-            as if it's gently flowing; blur softens it, displace bends it. */}
-        <svg
-          aria-hidden
-          width="0"
-          height="0"
-          className="pointer-events-none absolute"
-          style={{ position: "absolute", width: 0, height: 0 }}
-        >
-          <defs>
-            <filter
-              id="liquid-distortion"
-              x="-20%"
-              y="-20%"
-              width="140%"
-              height="140%"
-              filterUnits="objectBoundingBox"
-            >
-              <feTurbulence
-                type="fractalNoise"
-                baseFrequency="0.012 0.016"
-                numOctaves={2}
-                seed={7}
-                result="turbulence"
-              >
-                <animate
-                  attributeName="baseFrequency"
-                  dur="20s"
-                  values="0.012 0.016;0.018 0.011;0.012 0.016"
-                  repeatCount="indefinite"
-                />
-              </feTurbulence>
-              <feGaussianBlur in="turbulence" stdDeviation="2" result="softMap" />
-              <feDisplacementMap
-                in="SourceGraphic"
-                in2="softMap"
-                scale={38}
-                xChannelSelector="R"
-                yChannelSelector="G"
-              />
-            </filter>
-          </defs>
-        </svg>
       </body>
     </html>
   );

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -62,8 +62,9 @@ export default function RootLayout({
         <div className="noise" aria-hidden />
         {children}
         <CommandPalette />
-        {/* Refraction filter for .glass surfaces — warps the backdrop at
-            the edges. Turbulence → blur → displace; kept lightweight. */}
+        {/* Refraction filter for .liquid surfaces — ripples the backdrop
+            like water. The turbulence drifts over time so the gel looks
+            as if it's gently flowing; blur softens it, displace bends it. */}
         <svg
           aria-hidden
           width="0"
@@ -73,25 +74,32 @@ export default function RootLayout({
         >
           <defs>
             <filter
-              id="glass-distortion"
-              x="0%"
-              y="0%"
-              width="100%"
-              height="100%"
+              id="liquid-distortion"
+              x="-20%"
+              y="-20%"
+              width="140%"
+              height="140%"
               filterUnits="objectBoundingBox"
             >
               <feTurbulence
                 type="fractalNoise"
-                baseFrequency="0.02 0.02"
+                baseFrequency="0.012 0.016"
                 numOctaves={2}
-                seed={5}
+                seed={7}
                 result="turbulence"
-              />
-              <feGaussianBlur in="turbulence" stdDeviation="1.5" result="softMap" />
+              >
+                <animate
+                  attributeName="baseFrequency"
+                  dur="20s"
+                  values="0.012 0.016;0.018 0.011;0.012 0.016"
+                  repeatCount="indefinite"
+                />
+              </feTurbulence>
+              <feGaussianBlur in="turbulence" stdDeviation="2" result="softMap" />
               <feDisplacementMap
                 in="SourceGraphic"
                 in2="softMap"
-                scale={160}
+                scale={38}
                 xChannelSelector="R"
                 yChannelSelector="G"
               />

--- a/src/components/command-palette.tsx
+++ b/src/components/command-palette.tsx
@@ -162,7 +162,7 @@ export function CommandPalette() {
   let running = -1;
 
   return (
-    // The backdrop and the glass panel are kept as separate, top-level
+    // The backdrop and the liquid panel are kept as separate, top-level
     // animated elements. Neither has an opacity-animating ancestor —
     // otherwise Chromium withholds their backdrop-filter blur until the
     // ancestor's opacity settles, making the blur appear with a delay.
@@ -188,11 +188,11 @@ export function CommandPalette() {
           animate={{ opacity: 1, y: 0, scale: 1 }}
           exit={{ opacity: 0, y: -8, scale: 0.98 }}
           transition={{ duration: 0.22, ease: EASE_OUT_SOFT }}
-          // `position` + `top` are set inline: the `.glass` utility sets
+          // `position` + `top` are set inline: the `.liquid` utility sets
           // `position: relative`, which would otherwise override Tailwind's
           // `fixed` and drop the panel to its static position.
           style={{ position: "fixed", top: "12vh" }}
-          className="glass inset-x-4 z-[101] mx-auto w-auto max-w-xl overflow-hidden rounded-2xl shadow-2xl shadow-black/20"
+          className="liquid inset-x-4 z-[101] mx-auto w-auto max-w-xl overflow-hidden rounded-2xl shadow-2xl shadow-black/20"
         >
             <div className="flex items-center gap-3 border-b border-(--border) px-4">
               <span className="text-(--muted)" aria-hidden>

--- a/src/components/hero.tsx
+++ b/src/components/hero.tsx
@@ -49,7 +49,7 @@ export function Hero() {
 
         <motion.div
           variants={item}
-          className="glass inline-flex items-center gap-2 rounded-full px-3 py-1 text-xs font-medium text-(--muted)"
+          className="liquid inline-flex items-center gap-2 rounded-full px-3 py-1 text-xs font-medium text-(--muted)"
         >
           <span className="relative flex h-2 w-2">
             <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-(--color-accent-2) opacity-75" />
@@ -81,7 +81,7 @@ export function Hero() {
               href={s.href}
               target="_blank"
               rel="noopener noreferrer"
-              className="glass group rounded-full px-4 py-2 text-sm font-medium transition-all hover:-translate-y-0.5 hover:shadow-lg hover:shadow-black/5"
+              className="liquid group rounded-full px-4 py-2 text-sm font-medium transition-all hover:-translate-y-0.5 hover:shadow-lg hover:shadow-black/5"
             >
               {s.label}
               <span className="ml-1 inline-block text-(--muted) transition-transform group-hover:translate-x-0.5">

--- a/src/components/journey.tsx
+++ b/src/components/journey.tsx
@@ -70,7 +70,7 @@ export function Journey() {
       onMouseLeave={() => setPaused(false)}
     >
       {/* ---- the map ---- */}
-      <div className="glass overflow-hidden rounded-3xl lg:col-span-3">
+      <div className="liquid overflow-hidden rounded-3xl lg:col-span-3">
         <div className="flex items-center justify-between border-b border-(--border) px-5 py-3">
           <p className="font-mono text-xs tracking-wider text-(--muted)">
             EAST ASIA · 福岡 → 上海 → 東京
@@ -191,7 +191,7 @@ export function Journey() {
               onClick={() => setActive(i)}
               className={`group flex items-center gap-3 rounded-2xl border px-4 py-3 text-left transition-all ${
                 i === active
-                  ? "glass border-(--border)"
+                  ? "liquid border-(--border)"
                   : "border-transparent hover:bg-(--border)/40"
               }`}
             >

--- a/src/components/nav.tsx
+++ b/src/components/nav.tsx
@@ -30,7 +30,7 @@ export function Nav() {
     >
       <nav
         className={`flex w-full max-w-3xl items-center justify-between rounded-full px-5 py-2.5 transition-all duration-300 ${
-          scrolled ? "glass shadow-lg shadow-black/5" : "bg-transparent"
+          scrolled ? "liquid shadow-lg shadow-black/5" : "bg-transparent"
         }`}
       >
         <Link href="#top" className="group flex items-center gap-2">

--- a/src/components/skills.tsx
+++ b/src/components/skills.tsx
@@ -20,7 +20,7 @@ export function Skills() {
             ease: EASE_OUT_SOFT,
           }}
           whileHover={{ y: -3 }}
-          className="glass rounded-xl px-4 py-2.5 text-sm font-medium"
+          className="liquid rounded-xl px-4 py-2.5 text-sm font-medium"
         >
           {skill}
         </motion.span>

--- a/src/components/spotlight-card.tsx
+++ b/src/components/spotlight-card.tsx
@@ -12,7 +12,7 @@ type SpotlightCardProps = {
   children: ReactNode;
 };
 
-/** Glass card with a cursor-following spotlight and reveal animation. */
+/** Liquid card with a cursor-following spotlight and reveal animation. */
 export function SpotlightCard({ href, index = 0, children }: SpotlightCardProps) {
   const mx = useMotionValue(0);
   const my = useMotionValue(0);
@@ -37,7 +37,7 @@ export function SpotlightCard({ href, index = 0, children }: SpotlightCardProps)
         target="_blank"
         rel="noopener noreferrer"
         onMouseMove={handleMove}
-        className="group relative block h-full overflow-hidden rounded-2xl glass p-px transition-transform duration-300 hover:-translate-y-1"
+        className="group relative block h-full overflow-hidden rounded-2xl liquid p-px transition-transform duration-300 hover:-translate-y-1"
       >
         <motion.div
           className="pointer-events-none absolute inset-0 opacity-0 transition-opacity duration-300 group-hover:opacity-100"


### PR DESCRIPTION
## What

Reimagine the surfaces as **water / slime gel** instead of frosted glass.

The first attempt used per-element `backdrop-filter` + an SVG displacement filter. That broke on iOS Safari:

1. **Bleed** — `overflow: hidden` doesn't clip filtered content on WebKit, so the warped body spilled past the rounded corners.
2. **Scroll jank** — the backdrop-filter + animated SVG filter forced a full repaint every scroll frame.

This PR replaces that with a **CSS-only approach** that fixes both at the root.

## Approach

`.liquid` is now built entirely from cheap, GPU-friendly primitives — **no `backdrop-filter`, no SVG filter, no blend modes**:

- A **translucent tinted gel body** (plain `rgba`/gradients) the backdrop shows through — no blur, so nothing repaints on scroll and nothing escapes the clip.
- A **specular point** baked into the background gradient, a crisp wet rim and a volumetric inner shadow (`box-shadow`) for weight/depth.
- A **wet sheen** of light that slides across each surface, animated with **`transform` only** so it stays composited and never triggers a scroll repaint. Intensifies on hover. Disabled under `prefers-reduced-motion`.

Also removed the now-unused `#liquid-distortion` SVG filter and the `liquid-jiggle` keyframe.

## Composition with `main`

Rebuilt on top of current `main`, so it composes with the already-merged **dot-field background** (#978) and **kinetic hero** (#977): the liquid gel surfaces sit above the reactive dot grid, and the hero keeps its scramble + magnetic buttons (now wrapped in `liquid` chips).

## Notes

- `npm run lint` and `npm run build` pass.
- Verified visually in light + dark on desktop **and a 390×844 mobile viewport** — the gel chips/cards are fully contained within their rounded corners (no bleed), the sheen sweeps smoothly, and the dot-field shows through behind them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)