### PR TITLE
Experiment: kinetic typography + magnetic hero UI

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -159,12 +159,29 @@ body {
   background: linear-gradient(
     100deg,
     var(--color-accent) 0%,
-    var(--color-accent-2) 50%,
-    var(--color-accent-3) 100%
+    var(--color-accent-2) 35%,
+    var(--color-accent-3) 65%,
+    var(--color-accent) 100%
   );
+  /* Oversize the gradient so it can travel across the glyphs. */
+  background-size: 200% 100%;
   -webkit-background-clip: text;
   background-clip: text;
   color: transparent;
+  animation: gradient-sweep 6s linear infinite;
+}
+
+/* Kinetic colour sweep through the headline. */
+@keyframes gradient-sweep {
+  to {
+    background-position: 200% 0;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .gradient-text {
+    animation: none;
+  }
 }
 
 /* Animated aurora blobs */

--- a/src/components/hero.tsx
+++ b/src/components/hero.tsx
@@ -4,6 +4,8 @@ import Image from "next/image";
 import Link from "next/link";
 import { motion } from "motion/react";
 
+import { Magnetic } from "@/components/magnetic";
+import { ScrambleText } from "@/components/scramble-text";
 import { EASE_OUT_SOFT } from "@/lib/motion";
 import { site } from "@/lib/site";
 
@@ -62,7 +64,7 @@ export function Hero() {
           variants={item}
           className="text-balance text-4xl font-semibold leading-[1.05] tracking-tight sm:text-6xl md:text-7xl"
         >
-          Hi, I&apos;m <span className="gradient-text">{site.name}</span>.
+          Hi, I&apos;m <ScrambleText text={site.name} className="gradient-text" />.
           <br />
           {site.tagline}
         </motion.h1>
@@ -76,18 +78,19 @@ export function Hero() {
 
         <motion.div variants={item} className="flex flex-wrap items-center gap-3">
           {site.socials.map((s) => (
-            <Link
-              key={s.label}
-              href={s.href}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="glass group rounded-full px-4 py-2 text-sm font-medium transition-all hover:-translate-y-0.5 hover:shadow-lg hover:shadow-black/5"
-            >
-              {s.label}
-              <span className="ml-1 inline-block text-(--muted) transition-transform group-hover:translate-x-0.5">
-                ↗
-              </span>
-            </Link>
+            <Magnetic key={s.label}>
+              <Link
+                href={s.href}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="glass group rounded-full px-4 py-2 text-sm font-medium transition-shadow hover:shadow-lg hover:shadow-black/5"
+              >
+                {s.label}
+                <span className="ml-1 inline-block text-(--muted) transition-transform group-hover:translate-x-0.5">
+                  ↗
+                </span>
+              </Link>
+            </Magnetic>
           ))}
         </motion.div>
       </motion.div>

--- a/src/components/magnetic.tsx
+++ b/src/components/magnetic.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import { useRef, type ReactNode } from "react";
+
+type MagneticProps = {
+  children: ReactNode;
+  /** How strongly the element leans toward the cursor (0–1-ish). */
+  strength?: number;
+  className?: string;
+};
+
+/**
+ * Wraps an interactive element so it magnetically leans toward the
+ * cursor while hovered and springs back on leave. Inline-block so it
+ * keeps its place in a flex/inline flow. Disabled under
+ * `prefers-reduced-motion`.
+ */
+export function Magnetic({ children, strength = 0.35, className }: MagneticProps) {
+  const ref = useRef<HTMLSpanElement>(null);
+
+  function reduced() {
+    return (
+      typeof window !== "undefined" &&
+      window.matchMedia("(prefers-reduced-motion: reduce)").matches
+    );
+  }
+
+  function onMouseMove(e: React.MouseEvent) {
+    const el = ref.current;
+    if (!el || reduced()) return;
+    const r = el.getBoundingClientRect();
+    const x = e.clientX - (r.left + r.width / 2);
+    const y = e.clientY - (r.top + r.height / 2);
+    el.style.transform = `translate(${x * strength}px, ${y * strength}px)`;
+  }
+
+  function onMouseLeave() {
+    const el = ref.current;
+    if (el) el.style.transform = "";
+  }
+
+  return (
+    <span
+      ref={ref}
+      onMouseMove={onMouseMove}
+      onMouseLeave={onMouseLeave}
+      className={className}
+      style={{
+        display: "inline-block",
+        transition: "transform 0.3s var(--ease-out-soft)",
+        willChange: "transform",
+      }}
+    >
+      {children}
+    </span>
+  );
+}

--- a/src/components/scramble-text.tsx
+++ b/src/components/scramble-text.tsx
@@ -1,0 +1,78 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+
+const GLYPHS = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789@#%&*<>/";
+
+type ScrambleTextProps = {
+  /** The final, settled text. */
+  text: string;
+  className?: string;
+  /** Decode duration in ms. */
+  duration?: number;
+  /** Re-run the decode whenever the pointer enters. */
+  scrambleOnHover?: boolean;
+};
+
+/**
+ * Kinetic "decode" typography: the text lands scrambled and resolves
+ * left-to-right into the real characters, like a terminal coming online.
+ * Hovering re-runs it. Honours `prefers-reduced-motion`.
+ */
+export function ScrambleText({
+  text,
+  className,
+  duration = 1000,
+  scrambleOnHover = true,
+}: ScrambleTextProps) {
+  const [display, setDisplay] = useState(text);
+  const [runId, setRunId] = useState(0);
+  const frame = useRef<number>(0);
+
+  useEffect(() => {
+    if (
+      typeof window !== "undefined" &&
+      window.matchMedia("(prefers-reduced-motion: reduce)").matches
+    ) {
+      // `display` already initialises to `text`; nothing to animate.
+      return;
+    }
+
+    const start = performance.now();
+    const tick = (now: number) => {
+      const p = Math.min(1, (now - start) / duration);
+      // Ease the reveal so it accelerates as it settles.
+      const revealed = Math.floor(p * p * text.length);
+      let out = "";
+      for (let i = 0; i < text.length; i++) {
+        const ch = text[i];
+        if (ch === " ") {
+          out += " ";
+        } else if (i < revealed) {
+          out += ch;
+        } else {
+          out += GLYPHS[Math.floor(Math.random() * GLYPHS.length)];
+        }
+      }
+      setDisplay(out);
+      if (p < 1) {
+        frame.current = requestAnimationFrame(tick);
+      } else {
+        setDisplay(text);
+      }
+    };
+
+    frame.current = requestAnimationFrame(tick);
+    return () => cancelAnimationFrame(frame.current);
+  }, [text, duration, runId]);
+
+  return (
+    <span
+      className={className}
+      aria-label={text}
+      onMouseEnter={scrambleOnHover ? () => setRunId((n) => n + 1) : undefined}
+    >
+      <span aria-hidden>{display}</span>
+    </span>
+  );
+}


### PR DESCRIPTION
## What

A playground experiment in **kinetic typography** and tactile interaction — make the hero feel like it's coming alive rather than just fading in.

## Changes

- **`ScrambleText`** (`components/scramble-text.tsx`) — the name lands scrambled and **decodes left-to-right** into the real characters with an eased reveal (terminal-coming-online feel). Re-runs on hover. Keeps an accessible `aria-label` and bails out under `prefers-reduced-motion`.
- **`Magnetic`** (`components/magnetic.tsx`) — a small wrapper that makes the hero's social buttons **lean toward the cursor** and spring back on leave. Inline-block so it keeps its place in the flex flow; disabled under reduced motion.
- **`globals.css`** — the gradient headline now **continuously sweeps its colours** across the glyphs (oversized gradient + animated `background-position`), reduced-motion safe.
- **`hero.tsx`** — wire `ScrambleText` into the name and wrap each social link in `Magnetic`.

## Notes

- Self-contained to the hero; no changes to the glass treatment or data layer.
- `npm run lint` and `npm run build` both pass. Verified visually: confirmed the name decoding mid-animation and resolving cleanly, with the gradient sweep running and layout unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DocH9ow8uiMVb9zq2mGRg9)_