### PR TITLE
Experiment: cursor-reactive halftone dot-field background

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -167,68 +167,12 @@ body {
   color: transparent;
 }
 
-/* Animated aurora blobs */
-@keyframes drift {
-  0%,
-  100% {
-    transform: translate3d(0, 0, 0) scale(1);
-  }
-  33% {
-    transform: translate3d(6%, -8%, 0) scale(1.12);
-  }
-  66% {
-    transform: translate3d(-7%, 5%, 0) scale(0.94);
-  }
-}
-
-.aurora {
-  position: fixed;
-  inset: 0;
-  z-index: -1;
-  overflow: hidden;
-  pointer-events: none;
-}
-
-.aurora::before,
-.aurora::after {
-  content: "";
-  position: absolute;
-  width: 55vmax;
-  height: 55vmax;
-  border-radius: 50%;
-  filter: blur(80px);
-  opacity: 0.5;
-  will-change: transform;
-}
-
-.aurora::before {
-  top: -15%;
-  left: -10%;
-  background: radial-gradient(circle, var(--color-accent), transparent 65%);
-  animation: drift 18s var(--ease-out-soft) infinite;
-}
-
-.aurora::after {
-  bottom: -20%;
-  right: -10%;
-  background: radial-gradient(circle, var(--color-accent-2), transparent 65%);
-  animation: drift 22s var(--ease-out-soft) infinite reverse;
-}
-
-@media (prefers-color-scheme: dark) {
-  .aurora::before,
-  .aurora::after {
-    opacity: 0.32;
-  }
-}
+/* The animated background is now the cursor-reactive halftone dot field
+   (see components/dot-field.tsx), rendered on a <canvas>. */
 
 @media (prefers-reduced-motion: reduce) {
   html {
     scroll-behavior: auto;
-  }
-  .aurora::before,
-  .aurora::after {
-    animation: none;
   }
 }
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,6 +4,7 @@ import { GeistSans } from "geist/font/sans";
 
 import "./globals.css";
 import { CommandPalette } from "@/components/command-palette";
+import { DotField } from "@/components/dot-field";
 import { site } from "@/lib/site";
 
 const description = site.intro;
@@ -58,7 +59,7 @@ export default function RootLayout({
   return (
     <html lang="en" className={`${GeistSans.variable} ${GeistMono.variable}`}>
       <body className="antialiased">
-        <div className="aurora" aria-hidden />
+        <DotField />
         <div className="noise" aria-hidden />
         {children}
         <CommandPalette />

--- a/src/components/dot-field.tsx
+++ b/src/components/dot-field.tsx
@@ -1,0 +1,121 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+
+/**
+ * A full-viewport halftone dot grid drawn on a canvas. Dots are tiny and
+ * faint at rest; near the pointer they swell, brighten and tint toward
+ * the accent, so a soft spotlight of larger dots tracks the cursor. A
+ * slow ambient wave keeps the field breathing when the pointer is idle.
+ *
+ * Sits behind everything (z-index -1, pointer-events none). Under
+ * `prefers-reduced-motion` it renders a single static frame.
+ */
+export function DotField() {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const ctx = canvas.getContext("2d");
+    if (!ctx) return;
+
+    const reduce = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+
+    const GAP = 30; // grid spacing in CSS px
+    const BASE_R = 1; // resting dot radius
+    const MAX_R = 4.5; // radius right under the pointer
+    const REACH = 150; // pointer influence radius in CSS px
+
+    // Theme-aware ink: faint at rest, accent-tinted under the pointer.
+    const dark = window.matchMedia("(prefers-color-scheme: dark)").matches;
+    const base = dark ? [205, 210, 235] : [40, 40, 70];
+    const accent = dark ? [185, 150, 255] : [120, 80, 230];
+
+    let w = 0;
+    let h = 0;
+    let dpr = 1;
+    // Pointer starts off-screen so nothing is highlighted until it moves.
+    const pointer = { x: -9999, y: -9999 };
+
+    function resize() {
+      if (!canvas || !ctx) return;
+      dpr = Math.min(window.devicePixelRatio || 1, 2);
+      w = window.innerWidth;
+      h = window.innerHeight;
+      canvas.width = Math.floor(w * dpr);
+      canvas.height = Math.floor(h * dpr);
+      canvas.style.width = `${w}px`;
+      canvas.style.height = `${h}px`;
+      ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+    }
+
+    function draw(t: number) {
+      if (!ctx) return;
+      ctx.clearRect(0, 0, w, h);
+      const reach2 = REACH * REACH;
+
+      for (let y = GAP / 2; y < h; y += GAP) {
+        for (let x = GAP / 2; x < w; x += GAP) {
+          // Distance to pointer drives the swell/tint.
+          const dx = x - pointer.x;
+          const dy = y - pointer.y;
+          const d2 = dx * dx + dy * dy;
+          const prox = d2 < reach2 ? 1 - Math.sqrt(d2) / REACH : 0;
+
+          // Slow diagonal wave so the field breathes when idle.
+          const wave = reduce
+            ? 0
+            : 0.5 + 0.5 * Math.sin(x * 0.015 + y * 0.015 + t * 0.0012);
+
+          const r = BASE_R + (MAX_R - BASE_R) * prox + wave * 0.6;
+          const alpha = 0.12 + 0.55 * prox + wave * 0.06;
+
+          const cr = Math.round(base[0] + (accent[0] - base[0]) * prox);
+          const cg = Math.round(base[1] + (accent[1] - base[1]) * prox);
+          const cb = Math.round(base[2] + (accent[2] - base[2]) * prox);
+
+          ctx.beginPath();
+          ctx.fillStyle = `rgba(${cr}, ${cg}, ${cb}, ${alpha})`;
+          ctx.arc(x, y, r, 0, Math.PI * 2);
+          ctx.fill();
+        }
+      }
+    }
+
+    let raf = 0;
+    function loop(t: number) {
+      draw(t);
+      raf = requestAnimationFrame(loop);
+    }
+
+    function onPointerMove(e: PointerEvent) {
+      pointer.x = e.clientX;
+      pointer.y = e.clientY;
+    }
+
+    resize();
+    window.addEventListener("resize", resize);
+    window.addEventListener("pointermove", onPointerMove);
+
+    if (reduce) {
+      draw(0); // one static frame
+    } else {
+      raf = requestAnimationFrame(loop);
+    }
+
+    return () => {
+      cancelAnimationFrame(raf);
+      window.removeEventListener("resize", resize);
+      window.removeEventListener("pointermove", onPointerMove);
+    };
+  }, []);
+
+  return (
+    <canvas
+      ref={canvasRef}
+      aria-hidden
+      className="pointer-events-none fixed inset-0 -z-10"
+    />
+  );
+}


### PR DESCRIPTION
## What

A playground experiment that swaps the dreamy **aurora blobs** for a sharper, more graphic aesthetic: a **halftone dot grid** that reacts to the cursor.

## Changes

- **`DotField`** (`components/dot-field.tsx`) — a full-viewport `<canvas>` of evenly-spaced dots. At rest they're tiny and faint; within ~150px of the pointer they **swell, brighten and tint toward the accent**, so a soft spotlight of larger dots follows the cursor. A slow diagonal sine wave keeps the field gently breathing when the pointer is idle.
  - DPR-aware (capped at 2×), single `requestAnimationFrame` loop, listeners cleaned up on unmount.
  - Theme-aware (different ink/accent for light vs dark) and `prefers-reduced-motion`-aware (renders one static frame, no animation).
- **`layout.tsx`** — replace the `.aurora` div with `<DotField />`.
- **`globals.css`** — remove the now-unused `.aurora` styles and the `drift` keyframe.

## Notes

- Background-only; glass surfaces and content layout are untouched.
- `npm run lint` and `npm run build` both pass. Verified visually in light + dark with the pointer moved over the hero — the grid renders and the accent spotlight cluster swells around the cursor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DocH9ow8uiMVb9zq2mGRg9)_