### PR TITLE
Ignore TypeScript major bumps in Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,3 +5,8 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 20
+    ignore:
+      # TypeScript 7 (native compiler) is not yet supported by Next.js /
+      # typescript-eslint (peer range <6.1.0); stay on 6.x until they catch up.
+      - dependency-name: "typescript"
+        update-types: ["version-update:semver-major"]


### PR DESCRIPTION
## Why

Dependabot's TypeScript 6.0.3 → 7.0.2 bump (#988) broke the Vercel preview build. TypeScript 7 is the native Go-based compiler and Next.js 16.2 cannot load it as its type-checking API — the build fails at the "Running TypeScript" step with "It looks like you're trying to use TypeScript but do not have the required package(s) installed." typescript-eslint also caps its peer range at `<6.1.0`.

## What

- Add an `ignore` rule to `.github/dependabot.yml` so Dependabot skips major version bumps for `typescript`, keeping the repo on 6.x until Next.js and typescript-eslint support TS 7.

PR #988 itself was closed via `·@·d·ependabot i·gnore t·his major version`; this config makes the hold durable and documented.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015x6HoXt3XJtSQu1Mspm8fT

---
_Generated by [Claude Code](https://claude.ai/code/session_015x6HoXt3XJtSQu1Mspm8fT)_