### PR TITLE
chore: weekly dependency refresh (2026-08-03)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1683,9 +1683,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "26.1.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.1.tgz",
-      "integrity": "sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw==",
+      "version": "26.1.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.2.tgz",
+      "integrity": "sha512-Vu4a5UFA9rIIFJ7rB/Vaafh9lrCQszopTCx6KjFboXTGQbPNasehVR5TEiithSDGyd1DEiUByggTZsg8jukeIg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1693,9 +1693,9 @@
       }
     },
     "node_modules/@types/react": {
-      "version": "19.2.17",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.17.tgz",
-      "integrity": "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==",
+      "version": "19.2.18",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.18.tgz",
+      "integrity": "sha512-AnzbBERsrLKtk2XSfTbYRLjQPdy116Sty4q+T+Bp3IC4l6jNBvreVPAHmpq9qhXQM7CXZPjLVmGMw9sy+hxQ3w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1703,9 +1703,9 @@
       }
     },
     "node_modules/@types/react-dom": {
-      "version": "19.2.3",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
-      "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
+      "version": "19.2.4",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.4.tgz",
+      "integrity": "sha512-Bsc+QHgp+P/F02XDzNCY9jnZNCUuLki36KT7VKrTXXLdHf+vHMNZnW1rVu5DNW/rCK+fya3DATySbLM4yhtKUw==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
@@ -1911,16 +1911,16 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
@@ -2697,9 +2697,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3910,12 +3910,12 @@
       }
     },
     "node_modules/framer-motion": {
-      "version": "12.42.2",
-      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.42.2.tgz",
-      "integrity": "sha512-5XY9luDiu0oHfHBjpDthFMh0ES+122w6p/papSJBweMkO8Sn+PW2QaEgRblQBpWFnuvZS5qvarpt/hO2pjGmnw==",
+      "version": "12.43.0",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.43.0.tgz",
+      "integrity": "sha512-1eaL3RvR/kAlbG7UYcpMptEyzPoENO0c6w7ZnB3/hh2vSAz/6uGAFn6fdoqTBguNstf3MsFhJHsD/0DHiclG+g==",
       "license": "MIT",
       "dependencies": {
-        "motion-dom": "^12.42.2",
+        "motion-dom": "^12.43.0",
         "motion-utils": "^12.39.0",
         "tslib": "^2.4.0"
       },
@@ -5300,12 +5300,12 @@
       }
     },
     "node_modules/motion": {
-      "version": "12.42.2",
-      "resolved": "https://registry.npmjs.org/motion/-/motion-12.42.2.tgz",
-      "integrity": "sha512-Atvv11yUKIid41cVrRBDVX5m8tF8kNpExRSlbpt6APClhDjtwQssgFHhQzejxw7/7YYbjHSPKBVbHo05BuJT5Q==",
+      "version": "12.43.0",
+      "resolved": "https://registry.npmjs.org/motion/-/motion-12.43.0.tgz",
+      "integrity": "sha512-BQgQbSa9Hn3/mtbib0MK53y6JSANa+YKUKlaYnWzAVDH424RYQ5LVpV3pNiWH00BA2z4ojsSdMzqT7g2FQwjuQ==",
       "license": "MIT",
       "dependencies": {
-        "framer-motion": "^12.42.2",
+        "framer-motion": "^12.43.0",
         "tslib": "^2.4.0"
       },
       "peerDependencies": {
@@ -5326,9 +5326,9 @@
       }
     },
     "node_modules/motion-dom": {
-      "version": "12.42.2",
-      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.42.2.tgz",
-      "integrity": "sha512-5gIMWLp/PycBtJRJWRgjxke5n8dlvkSn2DrYW+tr3XcqAZY1xZh6BJyooJXCM8wdfM7wfMjkBJNLge1CKPUIRA==",
+      "version": "12.43.0",
+      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.43.0.tgz",
+      "integrity": "sha512-azKON4d9S65PEoFUiQTMTgPheEmzf2QngdRc50AKfJp9Q9mmcBVw22c8eMq9k8kxOFHdL7+WZY7N/5F/lwiDag==",
       "license": "MIT",
       "dependencies": {
         "motion-utils": "^12.39.0"

--- a/src/world/engine.ts
+++ b/src/world/engine.ts
@@ -126,12 +126,7 @@ export class Engine {
 
     const palette = readPalette();
     applyPalette(wasm, palette);
-    const atlas = new Uint8Array(
-      wasm.memory.buffer,
-      wasm.texPtr(),
-      TEX_COUNT * TEX_SIZE * TEX_SIZE * 4
-    );
-    await buildAtlas(atlas, data, palette);
+    await buildAtlas(atlasBuffer(wasm), data, palette);
 
     wasm.setPlayer(SPAWN.x, SPAWN.y, SPAWN.ang);
 
@@ -259,12 +254,7 @@ export class Engine {
   private async applyTheme(): Promise<void> {
     const palette = readPalette();
     applyPalette(this.wasm, palette);
-    const atlas = new Uint8Array(
-      this.wasm.memory.buffer,
-      this.wasm.texPtr(),
-      TEX_COUNT * TEX_SIZE * TEX_SIZE * 4
-    );
-    await buildAtlas(atlas, this.data, palette);
+    await buildAtlas(atlasBuffer(this.wasm), this.data, palette);
   }
 
   private drawMinimap(): void {
@@ -321,6 +311,14 @@ function applyPalette(wasm: WasmExports, p: Palette): void {
     packColor(p.bg),
     packColor(mixHex(p.bg, p.fg, 0.1)),
     packColor(mixHex(p.bg, p.fg, 0.035))
+  );
+}
+
+function atlasBuffer(wasm: WasmExports): Uint8Array {
+  return new Uint8Array(
+    wasm.memory.buffer,
+    wasm.texPtr(),
+    TEX_COUNT * TEX_SIZE * TEX_SIZE * 4
   );
 }
 


### PR DESCRIPTION
Weekly dependency refresh + light refactor.

## Updated
- `@types/node` 26.1.1 -> 26.1.2
- `@types/react` 19.2.17 -> 19.2.18
- `@types/react-dom` 19.2.3 -> 19.2.4
- `motion` 12.42.2 -> 12.43.0
- `brace-expansion` (transitive, via `typescript-eslint`) — closes [GHSA-mh99-v99m-4gvg](https://github.com/advisories/GHSA-mh99-v99m-4gvg) (DoS via unbounded expansion length), picked up automatically by `npm audit fix`

Everything else (`next`, `eslint-config-next`, `assemblyscript`, `fast-xml-parser`, `tailwindcss`, `@tailwindcss/postcss`, `react`/`react-dom` patch, `postcss` override) was already at latest via prior auto-merged Dependabot PRs and last week's refresh (#994) — this round just syncs `node_modules`/the lockfile within the existing `package.json` ranges.

## Skipped majors (re-verified, same blockers as prior weeks)
- **eslint 10.8.0** (open PR #995, can be closed/superseded by this PR): `eslint-plugin-react@7.37.5` (pulled in by `eslint-config-next@16.2.12`) caps `eslint` at `^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9.7` in `peerDependencies` — no eslint 10 support yet.
- **typescript 7.0.2** (ignored via `.github/dependabot.yml`): `typescript-eslint@8.46+` (used by `eslint-config-next`) caps `typescript` at `>=4.8.4 <6.1.0` in `peerDependencies`. TS 7 is a ground-up rewrite (native Go compiler); revisit once `typescript-eslint` adds support.

## Refactor (small, safe)
- `src/world/engine.ts`: extracted the repeated texture-atlas `Uint8Array` view construction (`Engine.create` and `applyTheme` both built the same `new Uint8Array(wasm.memory.buffer, wasm.texPtr(), TEX_COUNT * TEX_SIZE * TEX_SIZE * 4)`) into a shared `atlasBuffer()` module helper, matching the existing `applyPalette()` pattern. No behavior change.
- Considered and **skipped**: deduplicating the three `matchMedia("(pointer: coarse)")` checks in `src/components/world/world.tsx` against the existing `touch` state — two of the three call sites sit in closures with narrower dependency arrays (a mount-once `useEffect`, and an `enter` callback without `touch` in its deps), so swapping to `touch` would silently change reactivity rather than just remove duplication. Left as-is to keep this round low-risk; worth a dedicated look if picked up again.

## Verification
- `npm install` + `npm audit fix` (0 vulnerabilities after)
- `npm run lint` — clean
- `npm run build` (incl. `asm:build`) — clean
- Manual smoke test: ran the dev server, entered the 3D gallery, confirmed no console errors and the world reached "playing" phase with the refactored texture-atlas code path exercised.

🤖 Generated with a scheduled weekly-dep-refresh run.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>