### PR TITLE
fix: bump postcss to patch security advisory GHSA-fxqj-rqcc-2cmp

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5746,9 +5746,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.20",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.20.tgz",
-      "integrity": "sha512-lW616l85ucIQL+FocMmL7pQFPqBmwejrCMg+iPxyImlrANNJG9NHq/RkyCZopDhd8C3LA03PHRJDjkbGu8vvug==",
+      "version": "8.5.25",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.25.tgz",
+      "integrity": "sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==",
       "funding": [
         {
           "type": "opencollective",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "typescript": "^6.0.3"
   },
   "overrides": {
-    "postcss": "^8.5.10",
+    "postcss": "^8.5.25",
     "sharp": "^0.35.3"
   }
 }


### PR DESCRIPTION
## Summary
- GitHub sent a security advisory for `postcss` (transitive dep pulled in via `@tailwindcss/postcss` / `next`, pinned in `overrides`)
- Vulnerable range: `<=8.5.22` — [GHSA-fxqj-rqcc-2cmp](https://github.com/advisories/GHSA-fxqj-rqcc-2cmp) (incomplete fix of GHSA-6g55-p6wh-862q — attacker-controlled `sourceMappingURL` can read arbitrary `.map` files when `from` is unset)
- Bumped the `overrides.postcss` pin from `^8.5.10` to `^8.5.25` (latest patched release), which resolves postcss to `8.5.25` in the lockfile
- `npm audit` now reports 0 vulnerabilities; `npm run build` passes

## Test plan
- [x] `npm install`
- [x] `npm audit` → 0 vulnerabilities
- [x] `npm run build` → succeeds