### PR TITLE
Bump nanoid from 3.3.16 to 3.3.18

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5349,9 +5349,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",


### PR DESCRIPTION
Fixes Dependabot alert [#62](https://github.com/yhakamay/me/security/dependabot/62).

## Advisory
- **GHSA-2v37-7h3g-55p8** / CVE-2026-67213 — High
- `customAlphabet` / `customRandom` loop forever when called with `size: 0` (CWE-835), which can hang the calling thread.
- Patched in 3.3.17; this bumps to 3.3.18.

## Change
`nanoid` is a transitive runtime dependency via `postcss@8.5.25` (`^3.3.16`), so a lockfile-only bump resolves it — no `package.json` change needed.

## Verification
- `npm audit` → 0 vulnerabilities
- `npm run build` → passes (Next.js 16.2.12, TypeScript clean, all 8 static pages generated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)